### PR TITLE
Fix broken link to Setup page

### DIFF
--- a/index.md
+++ b/index.md
@@ -38,7 +38,7 @@ in the data.
 
 ## Software requirements
 
-Refer to the [Setup](setup/) section to install the required software to follow along this lesson.
+Refer to the [Setup](setup) section to install the required software to follow along this lesson.
 
 > ## Under development
 >


### PR DESCRIPTION
Remove trailing / from link (404 error) on index page to setup page.